### PR TITLE
Star background design fix

### DIFF
--- a/app/src/main/res/drawable/rounded_border_background.xml
+++ b/app/src/main/res/drawable/rounded_border_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white"/>
+    <corners android:radius="50dp"/>
+
+</shape>

--- a/app/src/main/res/drawable/rounded_border_background.xml
+++ b/app/src/main/res/drawable/rounded_border_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/white"/>
+    <solid android:color="@color/whiteTransparent"/>
     <corners android:radius="50dp"/>
 
 </shape>

--- a/app/src/main/res/layout/activity_user_profile.xml
+++ b/app/src/main/res/layout/activity_user_profile.xml
@@ -13,15 +13,33 @@
         android:layout_height="match_parent"
         android:scaleType="centerCrop" />
 
-    <com.like.LikeButton
-        android:id="@+id/star_button"
-        android:layout_width="50dp"
-        android:layout_height="50dp"
-        android:layout_gravity="right"
-        android:layout_margin="15dp"
-        app:icon_size="25dp"
-        app:icon_type="star">
-    </com.like.LikeButton>
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:background="@drawable/rounded_border_background"
+        android:layout_gravity="end"
+        android:layout_margin="5dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/star"
+            android:textSize="25sp"
+            android:layout_gravity="center_vertical"
+            android:layout_margin="5dp"/>
+
+        <com.like.LikeButton
+            android:id="@+id/star_button"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:padding="5dp"
+            app:icon_size="25dp"
+            app:icon_type="star">
+        </com.like.LikeButton>
+
+
+    </LinearLayout>
 
     <TextView
         android:id="@+id/userNameTextView"
@@ -33,6 +51,6 @@
         android:text="User Name"
         android:textAlignment="center"
         android:textColor="#f2f2f2"
-        android:textSize="20dp"
+        android:textSize="20sp"
         android:textStyle="bold" />
 </FrameLayout>

--- a/app/src/main/res/layout/activity_user_profile.xml
+++ b/app/src/main/res/layout/activity_user_profile.xml
@@ -13,41 +13,22 @@
         android:layout_height="match_parent"
         android:scaleType="centerCrop" />
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
+    <com.like.LikeButton
+        android:id="@+id/star_button"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_gravity="top|right"
+        android:layout_margin="15dp"
         android:background="@drawable/rounded_border_background"
-        android:layout_gravity="end"
-        android:layout_margin="5dp">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/star"
-            android:textSize="25sp"
-            android:layout_gravity="center_vertical"
-            android:layout_marginLeft="10dp"
-            android:layout_marginStart="10dp" />
-
-        <com.like.LikeButton
-            android:id="@+id/star_button"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            app:icon_size="25dp"
-            app:icon_type="star"
-            android:layout_gravity="center_vertical">
-        </com.like.LikeButton>
-
-
-    </LinearLayout>
+        app:icon_size="25dp"
+        app:icon_type="star" />
 
     <TextView
         android:id="@+id/userNameTextView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|center_horizontal"
-        android:background="#bd000000"
+        android:background="#4a21b4"
         android:padding="20dp"
         android:text="User Name"
         android:textAlignment="center"

--- a/app/src/main/res/layout/activity_user_profile.xml
+++ b/app/src/main/res/layout/activity_user_profile.xml
@@ -27,15 +27,16 @@
             android:text="@string/star"
             android:textSize="25sp"
             android:layout_gravity="center_vertical"
-            android:layout_margin="5dp"/>
+            android:layout_marginLeft="10dp"
+            android:layout_marginStart="10dp" />
 
         <com.like.LikeButton
             android:id="@+id/star_button"
             android:layout_width="50dp"
             android:layout_height="50dp"
-            android:padding="5dp"
             app:icon_size="25dp"
-            app:icon_type="star">
+            app:icon_type="star"
+            android:layout_gravity="center_vertical">
         </com.like.LikeButton>
 
 
@@ -52,5 +53,5 @@
         android:textAlignment="center"
         android:textColor="#f2f2f2"
         android:textSize="20sp"
-        android:textStyle="bold" />
+        android:textStyle="bold"/>
 </FrameLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#3F51B5</color>
     <color name="colorPrimaryDark">#303F9F</color>
     <color name="colorAccent">#FF4081</color>
+    <color name="white">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,5 @@
     <color name="colorPrimaryDark">#303F9F</color>
     <color name="colorAccent">#FF4081</color>
     <color name="white">#FFFFFF</color>
+    <color name="whiteTransparent">#80FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Sweeky</string>
+    <string name="star">star</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
     <string name="app_name">Sweeky</string>
-    <string name="star">star</string>
 </resources>


### PR DESCRIPTION
Modified design. Removed the text view 'star'. Why?
Two reasons:
1) The text view is not properly aligning still
2) We will add an animation to the background of the star view, so at that time we can show the text 'stared' for a second when the user click the star